### PR TITLE
[NRTM] [MCC-207677] Thread safe Trace Information

### DIFF
--- a/src/Medidata.CrossApplicationTracer/ITrace.cs
+++ b/src/Medidata.CrossApplicationTracer/ITrace.cs
@@ -1,9 +1,11 @@
-﻿namespace Medidata.CrossApplicationTracer
+﻿using System.Net;
+
+namespace Medidata.CrossApplicationTracer
 {
     /// <summary>
-    /// TraceProvider interface
+    /// Trace interface
     /// </summary>
-    public interface ITraceProvider
+    public interface ITrace
     {
         /// <summary>
         /// Gets a TraceId
@@ -29,6 +31,12 @@
         /// Gets a Trace for outgoing HTTP request.
         /// </summary>
         /// <returns>The trace</returns>
-        ITraceProvider GetNext();
+        ITrace GetNext();
+
+        /// <summary>
+        /// Adds trace information to headers
+        /// </summary>
+        /// <param name="headers"></param>
+        void AddTraceHeaders(WebHeaderCollection headers);
     }
 }

--- a/src/Medidata.CrossApplicationTracer/Medidata.CrossApplicationTracer.csproj
+++ b/src/Medidata.CrossApplicationTracer/Medidata.CrossApplicationTracer.csproj
@@ -42,8 +42,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Trace.cs" />
     <Compile Include="TraceProvider.cs" />
-    <Compile Include="ITraceProvider.cs" />
+    <Compile Include="ITrace.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZipkinSampler.cs" />
   </ItemGroup>

--- a/src/Medidata.CrossApplicationTracer/Properties/AssemblyInfo.cs
+++ b/src/Medidata.CrossApplicationTracer/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Medidata.CrossApplicationTracer")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions 2014")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.8")]
-[assembly: AssemblyFileVersion("1.0.0.8")]
-[assembly: AssemblyInformationalVersion("1.0.0.8")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyInformationalVersion("1.1.0.0")]
 [assembly: InternalsVisibleTo("Medidata.CrossApplicationTracer.Tests")]

--- a/src/Medidata.CrossApplicationTracer/Trace.cs
+++ b/src/Medidata.CrossApplicationTracer/Trace.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Globalization;
+using System.Net;
+
+namespace Medidata.CrossApplicationTracer
+{
+    /// <summary>
+    /// Trace class
+    /// </summary>
+    public class Trace : ITrace
+    {
+        /// <summary>
+        /// Header Trace Id Key
+        /// </summary>
+        public const string HeaderTraceIdKey = "X-B3-TraceId";
+
+        /// <summary>
+        /// Header Spam Id Key
+        /// </summary>
+        public const string HeaderSpanIdKey = "X-B3-SpanId";
+
+        /// <summary>
+        /// Header Parent Span Id Key
+        /// </summary>
+        public const string HeaderParentSpanIdKey = "X-B3-ParentSpanId";
+
+        /// <summary>
+        /// Header Sampled Key
+        /// </summary>
+        public const string HeaderSampledKey = "X-B3-Sampled";
+
+        /// <summary>
+        /// Gets a TraceId
+        /// </summary>
+        public string TraceId { get; }
+
+        /// <summary>
+        /// Gets a SpanId
+        /// </summary>
+        public string SpanId { get; }
+
+        /// <summary>
+        /// Gets a ParentSpanId
+        /// </summary>
+        public string ParentSpanId { get; }
+
+        /// <summary>
+        /// Gets IsSampled
+        /// </summary>
+        public bool IsSampled { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="traceId"></param>
+        /// <param name="spanId"></param>
+        /// <param name="parentSpanId"></param>
+        /// <param name="isSampled"></param>
+        internal Trace(string traceId, string spanId, string parentSpanId, bool isSampled)
+        {
+            TraceId = Parse(traceId) ? traceId : GenerateHexEncodedInt64FromNewGuid();
+            SpanId = Parse(spanId) ? spanId : TraceId;
+            ParentSpanId = Parse(parentSpanId) ? parentSpanId : string.Empty;
+            IsSampled = isSampled;
+        }
+        
+        /// <summary>
+        /// Gets a Trace for outgoing HTTP request.
+        /// </summary>
+        /// <returns>The trace</returns>
+        public ITrace GetNext()
+        {
+            return new Trace(
+                TraceId,
+                GenerateHexEncodedInt64FromNewGuid(),
+                SpanId,
+                IsSampled);
+        }
+
+        /// <summary>
+        /// Adds trace information to headers
+        /// </summary>
+        /// <param name="headers"></param>
+        public void AddTraceHeaders(WebHeaderCollection headers)
+        {
+            headers.Add(HeaderTraceIdKey, TraceId);
+            headers.Add(HeaderSpanIdKey, SpanId);
+            headers.Add(HeaderParentSpanIdKey, ParentSpanId);
+            headers.Add(HeaderSampledKey, IsSampled.ToString().ToLower());
+        }
+
+        /// <summary>
+        /// Parse id value
+        /// </summary>
+        /// <param name="value">header's value</param>
+        /// <returns>true: parsed</returns>
+        private bool Parse(string value)
+        {
+            long result;
+            return !string.IsNullOrWhiteSpace(value) && Int64.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out result);
+        }
+
+        /// <summary>
+        /// Generate a hex encoded Int64 from new Guid.
+        /// </summary>
+        /// <returns>The hex encoded int64</returns>
+        private string GenerateHexEncodedInt64FromNewGuid()
+        {
+            return Convert.ToString(BitConverter.ToInt64(Guid.NewGuid().ToByteArray(), 0), 16);
+        }
+    }
+}

--- a/src/Medidata.CrossApplicationTracer/Trace.cs
+++ b/src/Medidata.CrossApplicationTracer/Trace.cs
@@ -32,22 +32,22 @@ namespace Medidata.CrossApplicationTracer
         /// <summary>
         /// Gets a TraceId
         /// </summary>
-        public string TraceId { get; }
+        public string TraceId { get; private set; }
 
         /// <summary>
         /// Gets a SpanId
         /// </summary>
-        public string SpanId { get; }
+        public string SpanId { get; private set; }
 
         /// <summary>
         /// Gets a ParentSpanId
         /// </summary>
-        public string ParentSpanId { get; }
+        public string ParentSpanId { get; private set; }
 
         /// <summary>
         /// Gets IsSampled
         /// </summary>
-        public bool IsSampled { get; }
+        public bool IsSampled { get; private set; }
 
         /// <summary>
         /// Constructor

--- a/src/Medidata.CrossApplicationTracer/ZipkinSampler.cs
+++ b/src/Medidata.CrossApplicationTracer/ZipkinSampler.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Medidata.CrossApplicationTracer
 {
+    /// <summary>
+    /// Handles sampling rate and path blacklist
+    /// </summary>
     public class ZipkinSampler
     {
         private static Random random = new Random();
@@ -13,6 +14,11 @@ namespace Medidata.CrossApplicationTracer
         internal readonly List<string> dontSampleList;
         internal readonly float sampleRate;
       
+        /// <summary>
+        /// Zipkin Samplre constuctor
+        /// </summary>
+        /// <param name="dontSampleListCsv"></param>
+        /// <param name="configSampleRate"></param>
         public ZipkinSampler(string dontSampleListCsv, string configSampleRate)
         {
             var dontSampleList = new List<string>();
@@ -44,9 +50,15 @@ namespace Medidata.CrossApplicationTracer
             return false;
         }
 
+        /// <summary>
+        /// Calculates if current request should be sampled
+        /// </summary>
+        /// <param name="httpContext"></param>
+        /// <param name="sampled"></param>
+        /// <returns></returns>
         public virtual bool ShouldBeSampled(System.Web.HttpContextBase httpContext, string sampled)
         {
-            if ( httpContext == null )
+            if (httpContext == null)
             {
                 return false;
             }
@@ -57,9 +69,9 @@ namespace Medidata.CrossApplicationTracer
                 return result;
             }
 
-            if ( ! IsInDontSampleList(httpContext.Request.Path))
+            if (!IsInDontSampleList(httpContext.Request.Path))
             {
-                if ( random.NextDouble() <= sampleRate )
+                if (random.NextDouble() <= sampleRate)
                 {
                     return true;
                 }

--- a/tests/Medidata.CrossApplicationTracer.Tests/Medidata.CrossApplicationTracer.Tests.csproj
+++ b/tests/Medidata.CrossApplicationTracer.Tests/Medidata.CrossApplicationTracer.Tests.csproj
@@ -73,6 +73,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="TraceTests.cs" />
     <Compile Include="TraceProviderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZipkinSamplerTests.cs" />

--- a/tests/Medidata.CrossApplicationTracer.Tests/TraceProviderTests.cs
+++ b/tests/Medidata.CrossApplicationTracer.Tests/TraceProviderTests.cs
@@ -12,20 +12,20 @@ namespace Medidata.CrossApplicationTracer.Tests
     public class TraceProviderTests
     {
         [TestMethod]
-        public void ConstructorWithNullHttpContext()
+        public void GenerateTraceWithNullHttpContext()
         {
             // Arrange & Act
-            var traceProvider = new TraceProvider();
+            var trace = TraceProvider.GenerateTrace(null, null, null);
 
             // Assert
-            Convert.ToInt64(traceProvider.TraceId, 16);
-            Assert.AreEqual(traceProvider.TraceId, traceProvider.SpanId);
-            Assert.AreEqual(string.Empty, traceProvider.ParentSpanId);
-            Assert.AreEqual(false, traceProvider.IsSampled);
+            Convert.ToInt64(trace.TraceId, 16);
+            Assert.AreEqual(trace.TraceId, trace.SpanId);
+            Assert.AreEqual(string.Empty, trace.ParentSpanId);
+            Assert.AreEqual(false, trace.IsSampled);
         }
 
         [TestMethod]
-        public void ConstructorWithHttpContextHavingAllIdValues()
+        public void GenerateTraceWithHttpContextHavingAllIdValues()
         {
             // Arrange
             var fixture = new Fixture();
@@ -53,17 +53,17 @@ namespace Medidata.CrossApplicationTracer.Tests
             };
 
             // Act
-            var traceProvider = new TraceProvider(httpContext:httpContextFake);
+            var trace = TraceProvider.GenerateTrace(httpContextFake, null, null);
 
             // Assert
-            Assert.AreEqual(traceId, traceProvider.TraceId);
-            Assert.AreEqual(spanId, traceProvider.SpanId);
-            Assert.AreEqual(parentSpanId, traceProvider.ParentSpanId);
-            Assert.AreEqual(isSampled, traceProvider.IsSampled);
+            Assert.AreEqual(traceId, trace.TraceId);
+            Assert.AreEqual(spanId, trace.SpanId);
+            Assert.AreEqual(parentSpanId, trace.ParentSpanId);
+            Assert.AreEqual(isSampled, trace.IsSampled);
         }
 
         [TestMethod]
-        public void ConstructorWithHttpContextHavingIdValuesExceptIsSampled()
+        public void GenerateTraceWithHttpContextHavingIdValuesExceptIsSampled()
         {
             // Arrange
             var fixture = new Fixture();
@@ -93,17 +93,17 @@ namespace Medidata.CrossApplicationTracer.Tests
             sampleFilter.Expect(x => x.ShouldBeSampled(httpContextFake, null)).Return(expectedIsSampled);
 
             // Act
-            var traceProvider = new TraceProvider(sampleFilter, httpContextFake);
+            var trace = TraceProvider.GenerateTrace(sampleFilter, httpContextFake);
 
             // Assert
-            Assert.AreEqual(traceId, traceProvider.TraceId);
-            Assert.AreEqual(spanId, traceProvider.SpanId);
-            Assert.AreEqual(parentSpanId, traceProvider.ParentSpanId);
-            Assert.AreEqual(expectedIsSampled, traceProvider.IsSampled);
+            Assert.AreEqual(traceId, trace.TraceId);
+            Assert.AreEqual(spanId, trace.SpanId);
+            Assert.AreEqual(parentSpanId, trace.ParentSpanId);
+            Assert.AreEqual(expectedIsSampled, trace.IsSampled);
         }
 
         [TestMethod]
-        public void ConstructorWithHttpContextHavingInvalidIdValues()
+        public void GenerateTraceWithHttpContextHavingInvalidIdValues()
         {
             // Arrange
             var fixture = new Fixture();
@@ -134,18 +134,18 @@ namespace Medidata.CrossApplicationTracer.Tests
             sampleFilter.Expect(x => x.ShouldBeSampled(httpContextFake, sampled)).Return(expectedIsSampled);
 
             // Act
-            var traceProvider = new TraceProvider(sampleFilter, httpContextFake);
+            var trace = TraceProvider.GenerateTrace(sampleFilter, httpContextFake);
 
             // Assert
-            Assert.AreNotEqual(traceId, traceProvider.TraceId);
-            Convert.ToInt64(traceProvider.TraceId, 16);
-            Assert.AreEqual(traceProvider.TraceId, traceProvider.SpanId);
-            Assert.AreEqual(string.Empty, traceProvider.ParentSpanId);
-            Assert.AreEqual(expectedIsSampled, traceProvider.IsSampled);
+            Assert.AreNotEqual(traceId, trace.TraceId);
+            Convert.ToInt64(trace.TraceId, 16);
+            Assert.AreEqual(trace.TraceId, trace.SpanId);
+            Assert.AreEqual(string.Empty, trace.ParentSpanId);
+            Assert.AreEqual(expectedIsSampled, trace.IsSampled);
         }
 
         [TestMethod]
-        public void ConstructorWithHavingTraceProviderInHttpContext()
+        public void GenerateTraceWithHavingTraceProviderInHttpContext()
         {
             // Arrange
             var fixture = new Fixture();
@@ -178,7 +178,7 @@ namespace Medidata.CrossApplicationTracer.Tests
                 }
             };
 
-            var traceProvider1 = new TraceProvider(httpContext: httpContextFake1);
+            var trace1 = TraceProvider.GenerateTrace(httpContextFake1, null, null);
 
             var httpContextFake2 = new StubHttpContextBase
             {
@@ -186,25 +186,25 @@ namespace Medidata.CrossApplicationTracer.Tests
                 RequestGet = () => httpRequestFake,
                 ItemsGet = () => new StubIDictionary
                 {
-                    ItemGetObject = (k) => traceProvider1,
+                    ItemGetObject = (k) => trace1,
                     ItemSetObjectObject = (k, v) => { },
                     ContainsObject = (k) => true
                 }
             };
 
             // Act
-            var traceProvider2 = new TraceProvider(httpContext:httpContextFake2);
+            var trace2 = TraceProvider.GenerateTrace(httpContextFake2, null, null);
 
             // Assert
-            Assert.AreEqual(traceProvider2.TraceId, traceProvider1.TraceId);
-            Assert.AreEqual(traceProvider2.SpanId, traceProvider1.SpanId);
-            Assert.AreEqual(traceProvider2.ParentSpanId, traceProvider1.ParentSpanId);
-            Assert.AreEqual(traceProvider2.IsSampled, traceProvider1.IsSampled);
+            Assert.AreEqual(trace2.TraceId, trace1.TraceId);
+            Assert.AreEqual(trace2.SpanId, trace1.SpanId);
+            Assert.AreEqual(trace2.ParentSpanId, trace1.ParentSpanId);
+            Assert.AreEqual(trace2.IsSampled, trace1.IsSampled);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void ConstructorWithHttpContextHavingSameSpanAndParentSpan()
+        public void GenerateTraceWithHttpContextHavingSameSpanAndParentSpan()
         {
             // Arrange
             var fixture = new Fixture();
@@ -230,46 +230,7 @@ namespace Medidata.CrossApplicationTracer.Tests
             };
 
             // Act
-            new TraceProvider(httpContext: httpContextFake);
-        }
-
-        [TestMethod]
-        public void GetNext()
-        {
-            // Arrange
-            var fixture = new Fixture();
-            var traceId = fixture.Create<long>().ToString();
-            var spanId = fixture.Create<long>().ToString();
-            var parentSpanId = fixture.Create<long>().ToString();
-            var sampled = Convert.ToString(fixture.Create<bool>());
-
-            var httpRequestFake = new StubHttpRequestBase
-            {
-                HeadersGet = () => new NameValueCollection
-                {
-                    { "X-B3-TraceId", traceId },
-                    { "X-B3-SpanId", spanId },
-                    { "X-B3-ParentSpanId", parentSpanId },
-                    { "X-B3-Sampled", sampled },
-                }
-            };
-
-            var httpContextFake = new StubHttpContextBase
-            {
-                RequestGet = () => httpRequestFake,
-                ItemsGet = () => new ListDictionary()
-            };
-
-            var traceProvider = new TraceProvider(httpContext: httpContextFake);
-
-            // Act
-            var nextTraceProvider = traceProvider.GetNext();
-
-            // Assert
-            Assert.AreEqual(traceProvider.TraceId, nextTraceProvider.TraceId);
-            Convert.ToInt64(nextTraceProvider.SpanId, 16);
-            Assert.AreEqual(traceProvider.SpanId, nextTraceProvider.ParentSpanId);
-            Assert.AreEqual(traceProvider.IsSampled, nextTraceProvider.IsSampled);
+            TraceProvider.GenerateTrace(httpContextFake, null, null);
         }
     }
 }

--- a/tests/Medidata.CrossApplicationTracer.Tests/TraceTests.cs
+++ b/tests/Medidata.CrossApplicationTracer.Tests/TraceTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+
+namespace Medidata.CrossApplicationTracer.Tests
+{
+    [TestClass]
+    public class TraceTests
+    {
+        [TestMethod]
+        public void ConstructorWithNullParameters()
+        {
+            // Arrange & Act
+            var trace = new Trace(null, null, null, false);
+
+            // Assert
+            Convert.ToInt64(trace.TraceId, 16);
+            Assert.AreEqual(trace.TraceId, trace.SpanId);
+            Assert.AreEqual(string.Empty, trace.ParentSpanId);
+            Assert.AreEqual(false, trace.IsSampled);
+        }
+
+        [TestMethod]
+        public void ConstructorWithPositiveParameters()
+        {
+            // Arrance
+            var fixture = new Fixture();
+            var traceId = Convert.ToString(fixture.Create<long>(), 16);
+            var spanId = Convert.ToString(fixture.Create<long>(), 16);
+            var parentSpanId = Convert.ToString(fixture.Create<long>(), 16);
+            var isSampled = true;
+
+            // Act
+            var trace = new Trace(traceId, spanId, parentSpanId, isSampled);
+
+            // Assert
+            Assert.AreEqual(traceId, trace.TraceId);
+            Assert.AreEqual(spanId, trace.SpanId);
+            Assert.AreEqual(parentSpanId, trace.ParentSpanId);
+            Assert.AreEqual(isSampled, trace.IsSampled);
+        }
+
+        [TestMethod]
+        public void GetNext()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var traceId = fixture.Create<long>().ToString();
+            var spanId = fixture.Create<long>().ToString();
+            var parentSpanId = fixture.Create<long>().ToString();
+            var isSampled = fixture.Create<bool>();
+
+            var trace = new Trace(traceId, spanId, parentSpanId, isSampled);
+
+            // Act
+            var nextTrace = trace.GetNext();
+
+            // Assert
+            Assert.AreEqual(trace.TraceId, nextTrace.TraceId);
+            Convert.ToInt64(nextTrace.SpanId, 16);
+            Assert.AreEqual(trace.SpanId, nextTrace.ParentSpanId);
+            Assert.AreEqual(trace.IsSampled, nextTrace.IsSampled);
+        }
+
+        [TestMethod]
+        public void AddTraceHeaders()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var traceId = fixture.Create<long>().ToString();
+            var spanId = fixture.Create<long>().ToString();
+            var parentSpanId = fixture.Create<long>().ToString();
+            var isSampled = fixture.Create<bool>();
+
+            var trace = new Trace(traceId, spanId, parentSpanId, isSampled);
+            var headers = new WebHeaderCollection();
+
+            // Act
+            trace.AddTraceHeaders(headers);
+
+            // Assert
+            Assert.AreEqual(trace.TraceId, headers[Trace.HeaderTraceIdKey]);
+            Assert.AreEqual(trace.SpanId, headers[Trace.HeaderSpanIdKey]);
+            Assert.AreEqual(trace.ParentSpanId, headers[Trace.HeaderParentSpanIdKey]);
+            Assert.AreEqual(trace.IsSampled.ToString().ToLower(), headers[Trace.HeaderSampledKey]);
+        }
+    }
+}

--- a/tests/Medidata.CrossApplicationTracer.Tests/ZipkinSamplerTests.cs
+++ b/tests/Medidata.CrossApplicationTracer.Tests/ZipkinSamplerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Web.Fakes;
 using System.Collections.Specialized;
 


### PR DESCRIPTION
Changes:
- Separate Trace class and Generator of Trace
- HttpContext is only used when generating the Trace information
- Design document: https://docs.google.com/document/d/1M1v_FUXSN3nepv8UIpmdghPvMFgPi4LAd0en0Namx8s/edit

@kenyamat @lschreck-mdsol @BPONTES @cabbott @jcarres-mdsol 
Please review and merge.

Thanks,
Brent
