### PR TITLE
[MCC-207677] Thread safe TraceProvider

### DIFF
--- a/src/Medidata.CrossApplicationTracer/Properties/AssemblyInfo.cs
+++ b/src/Medidata.CrossApplicationTracer/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Medidata.CrossApplicationTracer")]
-[assembly: AssemblyCopyright("Copyright © Medidata Solutions 2014")]
+[assembly: AssemblyCopyright("Copyright © Medidata Solutions 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.8")]
-[assembly: AssemblyFileVersion("1.0.0.8")]
-[assembly: AssemblyInformationalVersion("1.0.0.8")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyInformationalVersion("1.1.0.0")]
 [assembly: InternalsVisibleTo("Medidata.CrossApplicationTracer.Tests")]

--- a/src/Medidata.CrossApplicationTracer/TraceProvider.cs
+++ b/src/Medidata.CrossApplicationTracer/TraceProvider.cs
@@ -97,18 +97,31 @@ namespace Medidata.CrossApplicationTracer
         }
 
         /// <summary>
+        /// private constructor to accept property values
+        /// </summary>
+        /// <param name="traceId"></param>
+        /// <param name="spanId"></param>
+        /// <param name="parentSpanId"></param>
+        /// <param name="isSampled"></param>
+        private TraceProvider(string traceId, string spanId, string parentSpanId, bool isSampled)
+        {
+            TraceId = traceId;
+            SpanId = spanId;
+            ParentSpanId = parentSpanId;
+            IsSampled = isSampled;
+        }
+
+        /// <summary>
         /// Gets a Trace for outgoing HTTP request.
         /// </summary>
         /// <returns>The trace</returns>
         public ITraceProvider GetNext()
         {
-            return new TraceProvider
-            {
-                TraceId = this.TraceId,
-                SpanId = GenerateHexEncodedInt64FromNewGuid(),
-                ParentSpanId = this.SpanId,
-                IsSampled = this.IsSampled
-            };
+            return new TraceProvider(
+                TraceId,
+                GenerateHexEncodedInt64FromNewGuid(),
+                SpanId,
+                IsSampled);
         }
 
         /// <summary>


### PR DESCRIPTION
avoid calling public constructor with unnecessary logic when doing get next span

*_\- this is a simple change to assure trace provider to work on background thread (aim). *_
local. adhoc-ok

will be closing other PR https://github.com/mdsol/Medidata.CrossApplicationTracer/pull/15
and update the document.

@kenyamat @lschreck-mdsol @BPONTES @cabbott 
Please review. 
Thanks
